### PR TITLE
Add pcr_bitmask to decrypt APIs

### DIFF
--- a/client-library/src/Attestation/AttestationClient/lib/AttestationClient.cpp
+++ b/client-library/src/Attestation/AttestationClient/lib/AttestationClient.cpp
@@ -71,7 +71,10 @@ public:
     va_end(args);
 
     if(level <= attest::AttestationLogger::Info)
+    {
       printf("[Attest][%s][%s]<%s:%d> %s\n", attest::AttestationLogger::LogLevelStrings[level].c_str(), log_tag, function, line, &str[0]);
+      fflush(stdout);
+    }
   }
 };
 

--- a/client-library/src/Attestation/AttestationClient/lib/AttestationClient.cpp
+++ b/client-library/src/Attestation/AttestationClient/lib/AttestationClient.cpp
@@ -130,13 +130,13 @@ int32_t ga_get_token(void *st, const uint8_t* app_data, uint32_t pcr, uint8_t* t
     }
 }
 
-int32_t ga_decrypt(void *st, uint8_t *cipher, size_t* len) {
+int32_t ga_decrypt(void *st, uint8_t *cipher, size_t* len, uint32_t pcr_bitmask) {
     if(!st) return (int32_t)attest::AttestationResult::ErrorCode::ERROR_FAILED_MEMORY_ALLOCATION;
     AttestationClient* attestation_client = static_cast<AttestationClient*>(st);
     unsigned char *plaintext = NULL;
     uint32_t plain_len = 0;
 
-    attest::AttestationResult res = attestation_client->Decrypt(attest::EncryptionType::NONE, cipher, *len, NULL, 0, &plaintext, &plain_len, attest::RsaScheme::RsaOaep, attest::RsaHashAlg::RsaSha256);
+    attest::AttestationResult res = attestation_client->Decrypt(attest::EncryptionType::NONE, cipher, *len, NULL, 0, &plaintext, &plain_len, attest::RsaScheme::RsaOaep, attest::RsaHashAlg::RsaSha256, pcr_bitmask);
     int32_t rc = (int32_t) res.code_;
 
     if(rc) return rc;

--- a/client-library/src/Attestation/AttestationClient/lib/AttestationClientImpl.cpp
+++ b/client-library/src/Attestation/AttestationClient/lib/AttestationClientImpl.cpp
@@ -247,7 +247,8 @@ AttestationResult AttestationClientImpl::Decrypt(const attest::EncryptionType en
                                                  unsigned char** decrypted_data,
                                                  uint32_t* decrypted_data_size,
                                                  const attest::RsaScheme rsaWrapAlgId,
-                                                 const attest::RsaHashAlg rsaHashAlgId) noexcept {
+                                                 const attest::RsaHashAlg rsaHashAlgId,
+                                                 uint32_t pcr_bitmask) noexcept {
     AttestationResult result(AttestationResult::ErrorCode::SUCCESS);
     if (encrypted_data == nullptr ||
         encrypted_data_size <= 0  ||
@@ -261,7 +262,7 @@ AttestationResult AttestationClientImpl::Decrypt(const attest::EncryptionType en
     }
     try {
         Tpm tpm;
-        PcrList list = attest::GetAttestationPcrList(0);
+        PcrList list = attest::GetAttestationPcrList(pcr_bitmask);
         PcrSet pcrValues = tpm.GetPCRValues(list, attestation_hash_alg);
 
         // For encryption type 'NONE', the encrypted data is expected to be the encrypted symmetric key

--- a/client-library/src/Attestation/AttestationClient/lib/AttestationClientImpl.h
+++ b/client-library/src/Attestation/AttestationClient/lib/AttestationClientImpl.h
@@ -87,6 +87,7 @@ public:
      * @param[in] encryption_metadata_size: The size of encryption metadata
      * @param[in] rsaWrapAlgId: Rsa wrap algorithm id.
      * @param[in] rsaHashAlgId: Rsa hash algorithm id.
+     * @param[in] pcr_bitmask: The PCR bitmask used for creating the ephemeral key.
      * @param[out] decrypted_data: The decrypted data (the memory is allocated by the method and the
      * caller is expected to free this memory by calling Attest::Free() method)
      * @param[out] decrypted_data_size: The size of decrypted data
@@ -101,7 +102,8 @@ public:
                                       unsigned char** decrypted_data,
                                       uint32_t* decrypted_data_size,
                                       const attest::RsaScheme rsaWrapAlgId = attest::RsaScheme::RsaEs,
-                                      const attest::RsaHashAlg rsaHashAlgId = attest::RsaHashAlg::RsaSha1) noexcept override;
+                                      const attest::RsaHashAlg rsaHashAlgId = attest::RsaHashAlg::RsaSha1,
+                                      uint32_t pcr_bitmask = 0) noexcept override;
 
     /*
      * @brief This API deallocates the memory previously allocated by the library

--- a/client-library/src/Attestation/AttestationClient/lib/include/AttestationClient.h
+++ b/client-library/src/Attestation/AttestationClient/lib/include/AttestationClient.h
@@ -80,6 +80,7 @@ public:
      * @param[out] decrypted_data_size: The size of decrypted data
      * @param[in] rsaWrapAlgId: Rsa wrap algorithm id. Defaults to RSAES for backcompat with MAA.
      * @param[in] rsaHashAlgId: Rsa hash algorithm id. Defaults to SHA1 for backcompat with mHSM.
+     * @param[in] pcr_bitmask: The PCR bitmask used to create the ephemeral key.
      * @return In case of success, AttestationResult object with error code ErrorCode::Success
      * will be returned. In case of failure, an appropriate ErrorCode and description will be returned.
      */
@@ -91,7 +92,8 @@ public:
                                               unsigned char** decrypted_data,
                                               uint32_t* decrypted_data_size,
                                               const attest::RsaScheme tpm2RsaAlgId = attest::RsaScheme::RsaEs,
-                                              const attest::RsaHashAlg tpm2HashAlgId = attest::RsaHashAlg::RsaSha1) noexcept = 0;
+                                              const attest::RsaHashAlg tpm2HashAlgId = attest::RsaHashAlg::RsaSha1,
+                                              uint32_t pcr_bitmask = 0) noexcept = 0;
 
     /**
      * @brief This API deallocates the memory previously allocated by the library
@@ -163,9 +165,11 @@ extern "C" {
     * This MUST use RSA[2048]-OEAP-SHA256, and decryption is done in-place.
     * @param[inout] cipher: encrypted value, plaintext will be written in place
     * @param[inout] len: encrypted value length, plaintext length will be written
+    * @param[in] pcr_bitmask: bitmask representing the PCRs used to decrypt the value.
+    * This value should match the PCRs used during fetching MAA token.
     * @return 0 on success, error code on failure (see AttestationLibTypes.h for mapping)
     */
     DllExports
-    int32_t ga_decrypt(void *st, uint8_t *cipher, size_t* len);
+    int32_t ga_decrypt(void *st, uint8_t *cipher, size_t* len, uint32_t pcr_bitmask);
 
 }


### PR DESCRIPTION
MAA token fetching API ga_get_token supports custom PCR selection. ga_decrypt() needs to match PCR selection to be able to decrypt token wrapped data.